### PR TITLE
Fix Bandcamp album parsing and persistence

### DIFF
--- a/lib/album_details_page.dart
+++ b/lib/album_details_page.dart
@@ -33,8 +33,9 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
     try {
       final response = await http.get(url);
       final data = jsonDecode(response.body);
-      var trackList =
-          data['results'].where((track) => track['wrapperType'] == 'track').toList();
+      var trackList = data['results']
+          .where((track) => track['wrapperType'] == 'track')
+          .toList();
       setState(() {
         tracks = trackList;
         trackList.forEach((track) => ratings[track['trackId']] = 0.0);
@@ -75,10 +76,11 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
     if (tracks.isEmpty) return 0.4; // Default value if no tracks
 
     // Adjust the width between 0.2 and 0.5 based on the size of the trackList
-    double calculatedWidth = (0.5 - (tracks.length / 100).clamp(0.0, 0.4)).toDouble();
+    double calculatedWidth =
+        (0.5 - (tracks.length / 100).clamp(0.0, 0.4)).toDouble();
     return calculatedWidth.clamp(0.2, 0.5);
   }
-  
+
   @override
   Widget build(BuildContext context) {
     double titleWidthFactor = _calculateTitleWidth();
@@ -148,9 +150,9 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
                       children: [
                         Text("Rating: ",
                             style: TextStyle(
-                                fontWeight: FontWeight.bold,
-                                fontSize: 20)),
-                        Text(averageRating.toStringAsFixed(2), style: TextStyle(fontSize: 20)),
+                                fontWeight: FontWeight.bold, fontSize: 20)),
+                        Text(averageRating.toStringAsFixed(2),
+                            style: TextStyle(fontSize: 20)),
                       ],
                     ),
                   ],
@@ -164,9 +166,10 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
                   style: TextStyle(color: Colors.white),
                 ),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).brightness == Brightness.dark
-                      ? AppTheme.darkTheme.colorScheme.primary
-                      : AppTheme.lightTheme.colorScheme.primary,
+                  backgroundColor:
+                      Theme.of(context).brightness == Brightness.dark
+                          ? AppTheme.darkTheme.colorScheme.primary
+                          : AppTheme.lightTheme.colorScheme.primary,
                 ),
               ),
               Divider(),
@@ -180,46 +183,52 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
                     DataColumn(
                         label: Text('Rating', textAlign: TextAlign.center)),
                   ],
-                  rows: tracks.map((track) => DataRow(
-                    cells: [
-                      DataCell(Text(track['trackNumber'].toString())),
-                      DataCell(
-                        Tooltip(
-                          message: track['trackName'],
-                          child: ConstrainedBox(
-                            constraints: BoxConstraints(
-                              maxWidth: MediaQuery.of(context).size.width * titleWidthFactor,
-                            ),
-                            child: Text(
-                              track['trackName'],
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                        ),
-                      ),
-                      DataCell(Text(formatDuration(track['trackTimeMillis']))),
-                      DataCell(Container(
-                        width: 150,
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: Slider(
-                                min: 0,
-                                max: 10,
-                                divisions: 10,
-                                value: ratings[track['trackId']] ?? 0.0,
-                                onChanged: (newRating) {
-                                  _updateRating(track['trackId'], newRating);
-                                },
+                  rows: tracks
+                      .map((track) => DataRow(
+                            cells: [
+                              DataCell(Text(track['trackNumber'].toString())),
+                              DataCell(
+                                Tooltip(
+                                  message: track['trackName'],
+                                  child: ConstrainedBox(
+                                    constraints: BoxConstraints(
+                                      maxWidth:
+                                          MediaQuery.of(context).size.width *
+                                              titleWidthFactor,
+                                    ),
+                                    child: Text(
+                                      track['trackName'],
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ),
                               ),
-                            ),
-                            Text((ratings[track['trackId']] ?? 0.0)
-                                .toStringAsFixed(0)),
-                          ],
-                        ),
-                      )),
-                    ],
-                  )).toList(),
+                              DataCell(Text(
+                                  formatDuration(track['trackTimeMillis']))),
+                              DataCell(Container(
+                                width: 150,
+                                child: Row(
+                                  children: [
+                                    Expanded(
+                                      child: Slider(
+                                        min: 0,
+                                        max: 10,
+                                        divisions: 10,
+                                        value: ratings[track['trackId']] ?? 0.0,
+                                        onChanged: (newRating) {
+                                          _updateRating(
+                                              track['trackId'], newRating);
+                                        },
+                                      ),
+                                    ),
+                                    Text((ratings[track['trackId']] ?? 0.0)
+                                        .toStringAsFixed(0)),
+                                  ],
+                                ),
+                              )),
+                            ],
+                          ))
+                      .toList(),
                 ),
               ),
               SizedBox(height: 20),
@@ -230,9 +239,10 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
                   style: TextStyle(color: Colors.white),
                 ),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).brightness == Brightness.dark
-                      ? AppTheme.darkTheme.colorScheme.primary
-                      : AppTheme.lightTheme.colorScheme.primary,
+                  backgroundColor:
+                      Theme.of(context).brightness == Brightness.dark
+                          ? AppTheme.darkTheme.colorScheme.primary
+                          : AppTheme.lightTheme.colorScheme.primary,
                 ),
               ),
               SizedBox(height: 20),
@@ -263,8 +273,7 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
 
   void _updateRating(int trackId, double newRating) async {
     setState(() {
-      ratings[trackId] =
-      newRating;
+      ratings[trackId] = newRating;
       calculateAverageRating();
     });
 
@@ -288,4 +297,3 @@ class _AlbumDetailsPageState extends State<AlbumDetailsPage> {
     }
   }
 }
-

--- a/lib/bandcamp_details_page.dart
+++ b/lib/bandcamp_details_page.dart
@@ -35,14 +35,12 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
 
   void _fetchTracksFromBandcamp() async {
     final url = widget.album['url'];
-    final collectionId =
-        widget.album['collectionId'] ?? UniqueIdGenerator.generateUniqueCollectionId();
 
     try {
       final response = await http.get(Uri.parse(url));
       if (response.statusCode == 200) {
         final document = parse(response.body);
-        final tracksData = BandcampParser.extractTracks(document, collectionId);
+        final tracksData = BandcampParser.extractTracks(document);
         final releaseDateData = BandcampParser.extractReleaseDate(document);
 
         tracksData.forEach((track) {
@@ -61,8 +59,8 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
       } else {
         throw Exception('Failed to load album page');
       }
-    } catch (error) {
-      print('Error fetching tracks: $error');
+    } catch (error, st) {
+      print('Error fetching tracks: $error $st');
       setState(() {
         isLoading = false;
       });
@@ -70,8 +68,10 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
   }
 
   void _loadRatings() async {
-    int albumId = widget.album['collectionId'] ?? UniqueIdGenerator.generateUniqueCollectionId();
-    List<Map<String, dynamic>> savedRatings = await UserData.getSavedAlbumRatings(albumId);
+    int albumId = widget.album['collectionId'] ??
+        UniqueIdGenerator.generateUniqueCollectionId();
+    List<Map<String, dynamic>> savedRatings =
+        await UserData.getSavedAlbumRatings(albumId);
     Map<int, double> ratingsMap = {};
     savedRatings.forEach((rating) {
       int trackId = rating['trackId'];
@@ -114,7 +114,8 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
       calculateAverageRating();
     });
 
-    int albumId = widget.album['collectionId'] ?? UniqueIdGenerator.generateUniqueCollectionId();
+    int albumId = widget.album['collectionId'] ??
+        UniqueIdGenerator.generateUniqueCollectionId();
     await UserData.saveRating(albumId, trackId, newRating);
     print('Updated rating for trackId $trackId: $newRating');
   }
@@ -126,9 +127,13 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
   }
 
   void _saveAlbum() async {
-    await UserData.saveAlbum(widget.album);  // Espera a que el álbum se guarde
-    List<int> trackIds = tracks.map((track) => track['trackId'] ?? 0).cast<int>().toList();
-    _printSavedIds(widget.album['collectionId'] ?? UniqueIdGenerator.generateUniqueCollectionId(), trackIds);
+    await UserData.saveAlbum(widget.album); // Espera a que el álbum se guarde
+    List<int> trackIds =
+        tracks.map((track) => track['trackId'] ?? 0).cast<int>().toList();
+    _printSavedIds(
+        widget.album['collectionId'] ??
+            UniqueIdGenerator.generateUniqueCollectionId(),
+        trackIds);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text('Album saved in history'),
@@ -195,25 +200,31 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Artist: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
-                              Text(widget.album['artistName'] ?? 'Unknown Artist'),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
+                              Text(widget.album['artistName'] ??
+                                  'Unknown Artist'),
                             ],
                           ),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Album: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
-                              Text(widget.album['collectionName'] ?? 'Unknown Album'),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
+                              Text(widget.album['collectionName'] ??
+                                  'Unknown Album'),
                             ],
                           ),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Release Date: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
                               Text(releaseDate != null
-                                  ? DateFormat('dd-MM-yyyy').format(releaseDate!)
+                                  ? DateFormat('dd-MM-yyyy')
+                                      .format(releaseDate!)
                                   : 'Unknown Date'),
                             ],
                           ),
@@ -221,7 +232,8 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Duration: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
                               Text(formatDuration(albumDurationMillis)),
                             ],
                           ),
@@ -230,7 +242,8 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
                             children: [
                               Text("Rating: ",
                                   style: TextStyle(
-                                      fontWeight: FontWeight.bold, fontSize: 20)),
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 20)),
                               Text(averageRating.toStringAsFixed(2),
                                   style: TextStyle(fontSize: 20)),
                             ],
@@ -246,27 +259,38 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
                         style: TextStyle(color: Colors.white),
                       ),
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Theme.of(context).brightness ==
-                                Brightness.dark
-                            ? AppTheme.darkTheme.colorScheme.primary
-                            : AppTheme.lightTheme.colorScheme.primary,
+                        backgroundColor:
+                            Theme.of(context).brightness == Brightness.dark
+                                ? AppTheme.darkTheme.colorScheme.primary
+                                : AppTheme.lightTheme.colorScheme.primary,
                       ),
                     ),
                     Divider(),
                     DataTable(
                       columns: const [
-                        DataColumn(label: Text('Track No.', textAlign: TextAlign.center)),
-                        DataColumn(label: Text('Title', textAlign: TextAlign.left)), // Alineación a la izquierda
-                        DataColumn(label: Text('Length', textAlign: TextAlign.center)),
-                        DataColumn(label: Text('Rating', textAlign: TextAlign.center)),
+                        DataColumn(
+                            label:
+                                Text('Track No.', textAlign: TextAlign.center)),
+                        DataColumn(
+                            label: Text('Title',
+                                textAlign: TextAlign
+                                    .left)), // Alineación a la izquierda
+                        DataColumn(
+                            label: Text('Length', textAlign: TextAlign.center)),
+                        DataColumn(
+                            label: Text('Rating', textAlign: TextAlign.center)),
                       ],
                       rows: tracks.map((track) {
                         final trackId = track['trackId'] ?? 0;
                         return DataRow(
                           cells: [
-                            DataCell(Center(child: Text(track['trackNumber'].toString()))),
-                            DataCell(Text(track['title'] ?? '')), // Alineación a la izquierda
-                            DataCell(Center(child: Text(formatDuration(track['duration'] ?? 0)))),
+                            DataCell(Center(
+                                child: Text(track['trackNumber'].toString()))),
+                            DataCell(Text(track['title'] ??
+                                '')), // Alineación a la izquierda
+                            DataCell(Center(
+                                child: Text(
+                                    formatDuration(track['duration'] ?? 0)))),
                             DataCell(
                               Center(
                                 child: SizedBox(
@@ -279,14 +303,16 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
                                           min: 0,
                                           max: 10,
                                           divisions: 10,
-                                          label: ratings[trackId]?.toStringAsFixed(0),
+                                          label: ratings[trackId]
+                                              ?.toStringAsFixed(0),
                                           onChanged: (newRating) {
                                             _updateRating(trackId, newRating);
                                           },
                                         ),
                                       ),
                                       Text(
-                                        ratings[trackId]?.toStringAsFixed(0) ?? '0',
+                                        ratings[trackId]?.toStringAsFixed(0) ??
+                                            '0',
                                         style: TextStyle(fontSize: 16),
                                       ),
                                     ],
@@ -306,10 +332,10 @@ class _BandcampDetailsPageState extends State<BandcampDetailsPage> {
                         style: TextStyle(color: Colors.white),
                       ),
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Theme.of(context).brightness ==
-                                Brightness.dark
-                            ? AppTheme.darkTheme.colorScheme.primary
-                            : AppTheme.lightTheme.colorScheme.primary,
+                        backgroundColor:
+                            Theme.of(context).brightness == Brightness.dark
+                                ? AppTheme.darkTheme.colorScheme.primary
+                                : AppTheme.lightTheme.colorScheme.primary,
                       ),
                     ),
                     SizedBox(height: 20),

--- a/lib/bandcamp_logic_page.dart
+++ b/lib/bandcamp_logic_page.dart
@@ -4,6 +4,8 @@ import 'package:html/parser.dart' show parse;
 import 'package:http/http.dart' as http;
 import 'bandcamp_parser.dart';
 
+import '../user_data.dart';
+
 class BandcampLogicPage extends ChangeNotifier {
   List<Map<String, dynamic>> tracks = [];
   Map<int, double> ratings = {};
@@ -15,7 +17,7 @@ class BandcampLogicPage extends ChangeNotifier {
     try {
       final response = await http.get(Uri.parse(url));
       final document = parse(response.body);
-      final extractedTracks = BandcampParser.extractTracks(document, collectionId);
+      final extractedTracks = BandcampParser.extractTracks(document);
       tracks = extractedTracks;
       extractedTracks.forEach((track) => ratings[track['trackId']] = 0.0);
       calculateAlbumDuration();

--- a/lib/bandcamp_saved_album_page.dart
+++ b/lib/bandcamp_saved_album_page.dart
@@ -30,7 +30,8 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
   @override
   void initState() {
     super.initState();
-    print('Init State: Starting to fetch tracks for album ${widget.album['collectionId']}');
+    print(
+        'Init State: Starting to fetch tracks for album ${widget.album['collectionId']}');
     _fetchTracks();
   }
 
@@ -39,7 +40,7 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
     try {
       final response = await http.get(url);
       final document = parse(response.body);
-      final extractedTracks = BandcampParser.extractTracks(document, widget.album['collectionId']);
+      final extractedTracks = BandcampParser.extractTracks(document);
       final releaseDateData = BandcampParser.extractReleaseDate(document);
       setState(() {
         tracks = extractedTracks;
@@ -152,7 +153,8 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Artist: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
                               Text("${widget.album['artistName']}"),
                             ],
                           ),
@@ -160,7 +162,8 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Album: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
                               Text("${widget.album['collectionName']}"),
                             ],
                           ),
@@ -168,7 +171,8 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Release Date: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
                               Text(
                                 releaseDate != null
                                     ? "${DateFormat('dd-MM-yyyy').format(releaseDate!)}"
@@ -180,7 +184,8 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text("Duration: ",
-                                  style: TextStyle(fontWeight: FontWeight.bold)),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold)),
                               Text(formatDuration(albumDurationMillis)),
                             ],
                           ),
@@ -191,7 +196,8 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
                                   style: TextStyle(
                                       fontWeight: FontWeight.bold,
                                       fontSize: 20)),
-                              Text(averageRating.toStringAsFixed(2), style: TextStyle(fontSize: 20)),
+                              Text(averageRating.toStringAsFixed(2),
+                                  style: TextStyle(fontSize: 20)),
                             ],
                           ),
                         ],
@@ -206,48 +212,61 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
                           DataColumn(label: Text('Track No.')),
                           DataColumn(label: Text('Title')),
                           DataColumn(label: Text('Length')),
-                          DataColumn(label: Text('Rating', textAlign: TextAlign.center)),
+                          DataColumn(
+                              label:
+                                  Text('Rating', textAlign: TextAlign.center)),
                         ],
-                        rows: tracks.map((track) => DataRow(
-                          cells: [
-                            DataCell(Text(track['trackNumber'].toString())),
-                            DataCell(
-                              Tooltip(
-                                message: track['title'],
-                                child: ConstrainedBox(
-                                  constraints: BoxConstraints(
-                                    maxWidth: MediaQuery.of(context).size.width * 0.3,
-                                  ),
-                                  child: Text(
-                                    track['title'],
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            DataCell(Text(formatDuration(track['duration'] as int))),
-                            DataCell(Container(
-                              width: 150,
-                              child: Row(
-                                children: [
-                                  Expanded(
-                                    child: Slider(
-                                      min: 0,
-                                      max: 10,
-                                      divisions: 10,
-                                      value: ratings[track['trackId']] ?? 0.0,
-                                      onChanged: (newRating) {
-                                        _updateRating(track['trackId'], newRating);
-                                      },
+                        rows: tracks
+                            .map((track) => DataRow(
+                                  cells: [
+                                    DataCell(
+                                        Text(track['trackNumber'].toString())),
+                                    DataCell(
+                                      Tooltip(
+                                        message: track['title'],
+                                        child: ConstrainedBox(
+                                          constraints: BoxConstraints(
+                                            maxWidth: MediaQuery.of(context)
+                                                    .size
+                                                    .width *
+                                                0.3,
+                                          ),
+                                          child: Text(
+                                            track['title'],
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                        ),
+                                      ),
                                     ),
-                                  ),
-                                  Text((ratings[track['trackId']] ?? 0.0)
-                                      .toStringAsFixed(0)),
-                                ],
-                              ),
-                            )),
-                          ],
-                        )).toList(),
+                                    DataCell(Text(formatDuration(
+                                        track['duration'] as int))),
+                                    DataCell(Container(
+                                      width: 150,
+                                      child: Row(
+                                        children: [
+                                          Expanded(
+                                            child: Slider(
+                                              min: 0,
+                                              max: 10,
+                                              divisions: 10,
+                                              value:
+                                                  ratings[track['trackId']] ??
+                                                      0.0,
+                                              onChanged: (newRating) {
+                                                _updateRating(track['trackId'],
+                                                    newRating);
+                                              },
+                                            ),
+                                          ),
+                                          Text(
+                                              (ratings[track['trackId']] ?? 0.0)
+                                                  .toStringAsFixed(0)),
+                                        ],
+                                      ),
+                                    )),
+                                  ],
+                                ))
+                            .toList(),
                       ),
                     ),
                     SizedBox(height: 20),
@@ -258,9 +277,10 @@ class _BandcampSavedAlbumPageState extends State<BandcampSavedAlbumPage> {
                         style: TextStyle(color: Colors.white),
                       ),
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Theme.of(context).brightness == Brightness.dark
-                            ? AppTheme.darkTheme.colorScheme.primary
-                            : AppTheme.lightTheme.colorScheme.primary,
+                        backgroundColor:
+                            Theme.of(context).brightness == Brightness.dark
+                                ? AppTheme.darkTheme.colorScheme.primary
+                                : AppTheme.lightTheme.colorScheme.primary,
                       ),
                     ),
                     SizedBox(height: 20),

--- a/lib/data_export.dart
+++ b/lib/data_export.dart
@@ -26,18 +26,20 @@ Future<void> exportSharedPreferencesToJson(BuildContext context) async {
     String path = file.path!;
 
     // Guardamos el archivo JSON en el directorio seleccionado.
-    File(filePath).writeAsStringSync(jsonData);
+    File(path).writeAsStringSync(jsonData);
 
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('Los datos de SharedPreferences se han exportado correctamente en: $path'),
+        content: Text(
+            'Los datos de SharedPreferences se han exportado correctamente en: $path'),
       ),
     );
   } else {
     // El usuario canceló la selección del archivo.
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('No se seleccionó ningún directorio para guardar el archivo.'),
+        content:
+            Text('No se seleccionó ningún directorio para guardar el archivo.'),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'id_generator.dart';
-import 'search_page.dart';
-import 'footer.dart';
+
 import 'app_theme.dart';
-import 'album_details_page.dart';
-import 'bandcamp_details_page.dart';
+import 'footer.dart';
+import 'id_generator.dart';
 import 'saved_preferences_page.dart';
 import 'saved_ratings_page.dart';
+import 'search_page.dart';
 import 'shared_preferences_page.dart';
 
 void main() async {
@@ -34,13 +33,17 @@ class _MusicRatingAppState extends State<MusicRatingApp> {
     final prefs = await SharedPreferences.getInstance();
     final brightnessIndex = prefs.getInt('themeBrightness');
     setState(() {
-      _themeBrightness = brightnessIndex != null ? Brightness.values[brightnessIndex] : Brightness.light;
+      _themeBrightness = brightnessIndex != null
+          ? Brightness.values[brightnessIndex]
+          : Brightness.light;
     });
   }
 
   void _toggleTheme() async {
     final prefs = await SharedPreferences.getInstance();
-    final newBrightness = _themeBrightness == Brightness.light ? Brightness.dark : Brightness.light;
+    final newBrightness = _themeBrightness == Brightness.light
+        ? Brightness.dark
+        : Brightness.light;
     await prefs.setInt('themeBrightness', newBrightness.index);
     setState(() {
       _themeBrightness = newBrightness;
@@ -55,7 +58,9 @@ class _MusicRatingAppState extends State<MusicRatingApp> {
     return MaterialApp(
       title: 'Rate Me!',
       debugShowCheckedModeBanner: false,
-      theme: _themeBrightness == Brightness.light ? AppTheme.lightTheme : AppTheme.darkTheme,
+      theme: _themeBrightness == Brightness.light
+          ? AppTheme.lightTheme
+          : AppTheme.darkTheme,
       home: MusicRatingHomePage(
         toggleTheme: _toggleTheme,
         themeBrightness: _themeBrightness!,
@@ -82,7 +87,8 @@ class MusicRatingHomePage extends StatelessWidget {
         leading: Tooltip(
           message: 'Saved Ratings',
           child: IconButton(
-            icon: Icon(Icons.star, size: 32, color: _getStarIconColor(themeBrightness)),
+            icon: Icon(Icons.star,
+                size: 32, color: _getStarIconColor(themeBrightness)),
             onPressed: () {
               Navigator.push(
                 context,
@@ -110,7 +116,8 @@ class MusicRatingHomePage extends StatelessWidget {
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => SharedPreferencesPage()),
+                  MaterialPageRoute(
+                      builder: (context) => SharedPreferencesPage()),
                 );
               },
             ),
@@ -132,6 +139,8 @@ class MusicRatingHomePage extends StatelessWidget {
   }
 
   Color _getStarIconColor(Brightness themeBrightness) {
-    return themeBrightness == Brightness.light ? AppTheme.lightTheme.colorScheme.primary : AppTheme.darkTheme.colorScheme.primary;
+    return themeBrightness == Brightness.light
+        ? AppTheme.lightTheme.colorScheme.primary
+        : AppTheme.darkTheme.colorScheme.primary;
   }
 }

--- a/lib/user_data.dart
+++ b/lib/user_data.dart
@@ -6,7 +6,7 @@ class UserData {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     List<String>? savedAlbumsJson = prefs.getStringList('saved_albums');
     List<String>? albumOrder = prefs.getStringList('savedAlbumsOrder');
-    
+
     if (savedAlbumsJson != null && albumOrder != null) {
       List<Map<String, dynamic>> savedAlbums = [];
       Map<String, Map<String, dynamic>> albumMap = {};
@@ -28,10 +28,12 @@ class UserData {
     }
   }
 
-  static Future<List<Map<String, dynamic>>> getSavedAlbumRatings(int albumId) async {
+  static Future<List<Map<String, dynamic>>> getSavedAlbumRatings(
+      int albumId) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    List<String>? savedRatingsJson = prefs.getStringList('saved_ratings_$albumId');
-    
+    List<String>? savedRatingsJson =
+        prefs.getStringList('saved_ratings_$albumId');
+
     if (savedRatingsJson != null) {
       List<Map<String, dynamic>> savedRatings = [];
 
@@ -59,7 +61,8 @@ class UserData {
     });
 
     if (existingIndex != -1) {
-      Map<String, dynamic> existingAlbum = jsonDecode(savedAlbumsJson[existingIndex]);
+      Map<String, dynamic> existingAlbum =
+          jsonDecode(savedAlbumsJson[existingIndex]);
       existingAlbum.addAll(album);
       savedAlbumsJson[existingIndex] = jsonEncode(existingAlbum);
     } else {
@@ -83,7 +86,8 @@ class UserData {
         savedAlbums.add(jsonDecode(json));
       }
 
-      savedAlbums.removeWhere((savedAlbum) => savedAlbum['collectionId'] == album['collectionId']);
+      savedAlbums.removeWhere(
+          (savedAlbum) => savedAlbum['collectionId'] == album['collectionId']);
       albumOrder.remove(album['collectionId'].toString());
 
       savedAlbumsJson = savedAlbums.map((album) => jsonEncode(album)).toList();
@@ -111,17 +115,27 @@ class UserData {
     return albumIds ?? [];
   }
 
-  static Future<void> saveRating(int albumId, int trackId, double rating) async {
+  static Future<void> saveRating(
+      int albumId, int trackId, double rating) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    List<String>? savedRatingsJson = prefs.getStringList('saved_ratings_$albumId');
-    
-    if (savedRatingsJson == null) {
-      savedRatingsJson = [];
-    }
+    List<String> savedRatingsJson =
+        prefs.getStringList('saved_ratings_$albumId') ?? [];
 
-    Map<String, dynamic> ratingData = {'trackId': trackId, 'rating': rating};
-    String ratingJson = jsonEncode(ratingData);
-    savedRatingsJson.add(ratingJson);
+    int trackIndex = savedRatingsJson.indexWhere((json) {
+      Map<String, dynamic> ratingData = jsonDecode(json);
+      return ratingData['trackId'] == trackId;
+    });
+
+    if (trackIndex != -1) {
+      Map<String, dynamic> ratingData =
+          jsonDecode(savedRatingsJson[trackIndex]);
+      ratingData['rating'] = rating;
+      savedRatingsJson[trackIndex] = jsonEncode(ratingData);
+    } else {
+      Map<String, dynamic> ratingData = {'trackId': trackId, 'rating': rating};
+      String ratingJson = jsonEncode(ratingData);
+      savedRatingsJson.add(ratingJson);
+    }
 
     await prefs.setStringList('saved_ratings_$albumId', savedRatingsJson);
   }
@@ -129,11 +143,11 @@ class UserData {
   static Future<Map<String, dynamic>?> getSavedAlbumById(int albumId) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     List<String>? savedAlbumsJson = prefs.getStringList('saved_albums');
-    
+
     if (savedAlbumsJson != null) {
       for (String json in savedAlbumsJson) {
         Map<String, dynamic> album = jsonDecode(json);
-        
+
         if (album['collectionId'] == albumId) {
           return album;
         }
@@ -154,7 +168,8 @@ class UserData {
     }
   }
 
-  static Future<void> saveAlbumTrackIds(int collectionId, List<int> trackIds) async {
+  static Future<void> saveAlbumTrackIds(
+      int collectionId, List<int> trackIds) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     String key = 'album_track_ids_$collectionId';
     List<String> trackIdsStr = trackIds.map((id) => id.toString()).toList();
@@ -170,7 +185,8 @@ class UserData {
       for (String json in savedAlbumsJson) {
         Map<String, dynamic> album = jsonDecode(json);
         int albumId = album['collectionId'];
-        List<Map<String, dynamic>> ratings = await getSavedAlbumRatings(albumId);
+        List<Map<String, dynamic>> ratings =
+            await getSavedAlbumRatings(albumId);
         ratingsMap[albumId] = ratings;
       }
 


### PR DESCRIPTION
This is a quick and dirty fix that parses the album and track data from the embedded json object in the Bandcamp album pages, fixes duplicate track ratings being saved and fixes the persistence problem for saved bandcamp albums.

I just focused on the issues we discussed and kept the overall design and storage solution being used.
Rewriting the entire app to use a proper storage solution, model objects, etc. was out of scope.